### PR TITLE
Add more auth pages

### DIFF
--- a/app/_types/button-type.tsx
+++ b/app/_types/button-type.tsx
@@ -1,5 +1,0 @@
-enum ButtonTypeEnum {
-  primary = "primary",
-  secondary = "secondary",
-}
-export type ButtonType = keyof typeof ButtonTypeEnum;

--- a/app/_types/button-type.tsx
+++ b/app/_types/button-type.tsx
@@ -1,0 +1,5 @@
+enum ButtonTypeEnum {
+  primary = "primary",
+  secondary = "secondary",
+}
+export type ButtonType = keyof typeof ButtonTypeEnum;

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,7 +1,73 @@
 "use client";
 
 import React, { useState } from "react";
+import Link from "next/link";
 
 export default function Page() {
-  return <div>FORGOTPASSWORD</div>;
+  const [email, setEmail] = useState("");
+  const [emailSent, setEmailSent] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!email) {
+      alert("Please enter an email address.");
+      return;
+    }
+    setEmailSent(true);
+  };
+
+  return (
+    <div className="flex h-screen items-center justify-center">
+      {emailSent ? (
+        <div className="text-center">
+          <h2 className="mb-4 text-4xl font-bold">Check your email</h2>
+          <p className="mb-6">
+            A password reset link was sent to{" "}
+            <span className="font-bold">{email}</span>.
+          </p>
+          <Link
+            href="/login"
+            className="mb-2 cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
+          >
+            back to login
+          </Link>
+        </div>
+      ) : (
+        <form
+          onSubmit={handleSubmit}
+          className="flex w-80 flex-col items-center"
+        >
+          {/* Title */}
+          <h1 className="font-display mb-4 block text-center text-5xl leading-none text-lion md:text-8xl">
+            reset password
+          </h1>
+
+          {/* Email */}
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
+          />
+
+          <div className="flex w-full items-center justify-between">
+            {/* Forgot Password */}
+            <Link href="/login" className="mb-8 text-xs">
+              Remembered password?
+            </Link>
+
+            {/* Email Button */}
+            <button
+              type="submit"
+              className="mb-2 cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
+            >
+              send reset link
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
 }

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -2,10 +2,13 @@
 
 import React, { useState } from "react";
 import Link from "next/link";
+import MessagePage from "../ui/components/message-page";
+import { useRouter } from "next/navigation";
 
 export default function Page() {
   const [email, setEmail] = useState("");
   const [emailSent, setEmailSent] = useState(false);
+  const router = useRouter();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -20,19 +23,17 @@ export default function Page() {
   return (
     <div className="flex h-screen items-center justify-center">
       {emailSent ? (
-        <div className="text-center">
-          <h2 className="mb-4 text-4xl font-bold">Check your email</h2>
-          <p className="mb-6">
-            A password reset link was sent to{" "}
-            <span className="font-bold">{email}</span>.
-          </p>
-          <Link
-            href="/login"
-            className="mb-2 cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
-          >
-            back to login
-          </Link>
-        </div>
+        <MessagePage
+          title="Check your email"
+          description={`A password reset link was sent to ${email}.`}
+          buttons={[
+            {
+              type: "primary",
+              label: "back to login",
+              onClick: () => router.push("/login"),
+            },
+          ]}
+        />
       ) : (
         <form
           onSubmit={handleSubmit}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -31,7 +31,7 @@ export default function Page() {
 
         {/* Email */}
         <input
-          type="text"
+          type="email"
           placeholder="Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,14 +1,11 @@
 "use client";
 
+import { useRouter, useSearchParams } from "next/navigation";
 import React, { useState } from "react";
-import { useSearchParams } from "next/navigation";
-import MessagePage from "../ui/components/message-page";
-import { useRouter } from "next/navigation";
 
 export default function Page() {
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [passwordReset, setPasswordReset] = useState(false);
   const router = useRouter();
 
   const searchParams = useSearchParams();
@@ -27,67 +24,50 @@ export default function Page() {
       return;
     }
 
-    // TODO: Replace with real sign up information
+    // TODO: Replace with real password reset API call
     if (newPassword !== confirmPassword) {
       alert("Passwords do not match.");
     } else {
-      setPasswordReset(true);
+      router.push("/reset-password/success");
     }
   };
 
   return (
     <div className="flex h-screen items-center justify-center">
-      {passwordReset ? (
-        <MessagePage
-          title="Password Reset Successful"
-          description=""
-          buttons={[
-            {
-              type: "primary",
-              label: "back to login",
-              onClick: () => router.push("/login"),
-            },
-          ]}
+      <form onSubmit={handleSubmit} className="flex w-80 flex-col items-center">
+        {/* Title */}
+        <h1 className="font-display mb-4 block text-center text-5xl leading-none text-lion md:text-8xl">
+          reset password
+        </h1>
+
+        {/* New Password */}
+        <input
+          type="password"
+          placeholder="New Password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
         />
-      ) : (
-        <form
-          onSubmit={handleSubmit}
-          className="flex w-80 flex-col items-center"
-        >
-          {/* Title */}
-          <h1 className="font-display mb-4 block text-center text-5xl leading-none text-lion md:text-8xl">
+
+        {/* Confirm Password */}
+        <input
+          type="password"
+          placeholder="Confirm Password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
+        />
+
+        {/* Change Password Button */}
+        <div className="flex w-full">
+          <button
+            type="submit"
+            className="mb-2 ml-auto cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
+          >
             reset password
-          </h1>
-
-          {/* New Password */}
-          <input
-            type="password"
-            placeholder="New Password"
-            value={newPassword}
-            onChange={(e) => setNewPassword(e.target.value)}
-            className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
-          />
-
-          {/* Confirm Password */}
-          <input
-            type="password"
-            placeholder="Confirm Password"
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
-          />
-
-          {/* Change Password Button */}
-          <div className="flex w-full">
-            <button
-              type="submit"
-              className="mb-2 ml-auto cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
-            >
-              reset password
-            </button>
-          </div>
-        </form>
-      )}
+          </button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -2,14 +2,28 @@
 
 import React, { useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 
 export default function Page() {
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [passwordReset, setPasswordReset] = useState(false);
 
+  const searchParams = useSearchParams();
+  const pwdResetToken = searchParams.get("token");
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (!pwdResetToken) {
+      alert("Invalid or missing password reset token.");
+      return;
+    }
+
+    if (!newPassword || !confirmPassword) {
+      alert("Please fill in all fields.");
+      return;
+    }
 
     // TODO: Replace with real sign up information
     if (newPassword !== confirmPassword) {

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import React, { useState } from "react";
-import Link from "next/link";
 import { useSearchParams } from "next/navigation";
+import MessagePage from "../ui/components/message-page";
+import { useRouter } from "next/navigation";
 
 export default function Page() {
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [passwordReset, setPasswordReset] = useState(false);
+  const router = useRouter();
 
   const searchParams = useSearchParams();
   const pwdResetToken = searchParams.get("token");
@@ -36,15 +38,17 @@ export default function Page() {
   return (
     <div className="flex h-screen items-center justify-center">
       {passwordReset ? (
-        <div className="text-center">
-          <h2 className="mb-6 text-4xl font-bold">Password Reset Successful</h2>
-          <Link
-            href="/login"
-            className="mb-2 cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
-          >
-            back to login
-          </Link>
-        </div>
+        <MessagePage
+          title="Password Reset Successful"
+          description=""
+          buttons={[
+            {
+              type: "primary",
+              label: "back to login",
+              onClick: () => router.push("/login"),
+            },
+          ]}
+        />
       ) : (
         <form
           onSubmit={handleSubmit}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+
+export default function Page() {
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [passwordReset, setPasswordReset] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // TODO: Replace with real sign up information
+    if (newPassword !== confirmPassword) {
+      alert("Passwords do not match.");
+    } else {
+      setPasswordReset(true);
+    }
+  };
+
+  return (
+    <div className="flex h-screen items-center justify-center">
+      {passwordReset ? (
+        <div className="text-center">
+          <h2 className="mb-6 text-4xl font-bold">Password Reset Successful</h2>
+          <Link
+            href="/login"
+            className="mb-2 cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
+          >
+            back to login
+          </Link>
+        </div>
+      ) : (
+        <form
+          onSubmit={handleSubmit}
+          className="flex w-80 flex-col items-center"
+        >
+          {/* Title */}
+          <h1 className="font-display mb-4 block text-center text-5xl leading-none text-lion md:text-8xl">
+            reset password
+          </h1>
+
+          {/* New Password */}
+          <input
+            type="password"
+            placeholder="New Password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
+          />
+
+          {/* Confirm Password */}
+          <input
+            type="password"
+            placeholder="Confirm Password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
+          />
+
+          {/* Change Password Button */}
+          <div className="flex w-full">
+            <button
+              type="submit"
+              className="mb-2 ml-auto cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
+            >
+              reset password
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/app/reset-password/success/page.tsx
+++ b/app/reset-password/success/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import MessagePage from "../../ui/components/message-page";
+
+export default function Page() {
+  const router = useRouter();
+
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <MessagePage
+        title="Password Reset Successful"
+        description=""
+        buttons={[
+          {
+            type: "primary",
+            label: "back to login",
+            onClick: () => router.push("/login"),
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/app/sign-up/email-sent/page.tsx
+++ b/app/sign-up/email-sent/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import MessagePage from "../../ui/components/message-page";
+import { useEffect } from "react";
+
+export default function Page() {
+  const router = useRouter();
+  const email = sessionStorage.getItem("sign_up_email");
+
+  useEffect(() => {
+    if (!email) {
+      // the user shouldn't be here
+      router.push("/login");
+    }
+    // clear the email from storage
+    sessionStorage.removeItem("sign_up_email");
+  }, []);
+
+  if (!email) {
+    // stop rendering if there's no email
+    return null;
+  }
+
+  const handleResendEmail = () => {
+    console.log("Resending email to:", email);
+    // TODO: Replace with real resend email API logic
+  };
+
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <MessagePage
+        title="Check your email"
+        description={`A verification link was sent to ${email}.`}
+        buttons={[
+          {
+            type: "secondary",
+            label: "resend email",
+            onClick: handleResendEmail,
+          },
+          {
+            type: "primary",
+            label: "go to login",
+            onClick: () => router.push("/login"),
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -2,13 +2,12 @@
 
 import React, { useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 
 export default function Page() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const router = useRouter();
+  const [emailSent, setEmailSent] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -18,71 +17,99 @@ export default function Page() {
       confirmPassword,
     });
 
-    // TODO: Replace with real sign up information
-    if (
-      email === "test" &&
-      password === "1234" &&
-      confirmPassword === password
-    ) {
-      router.push("/dashboard");
+    // TODO: Replace with real sign up API logic
+    if (email && password && confirmPassword === password) {
+      setEmailSent(true);
     } else {
       alert("WOMP WOMP NO ACCOUNT FOR YOU");
     }
   };
 
+  const handleResendEmail = () => {
+    console.log("Resending email to:", email);
+    // TODO: Replace with real resend email API logic
+  };
+
   return (
     <div className="flex h-screen items-center justify-center">
-      <form onSubmit={handleSubmit} className="flex w-80 flex-col items-center">
-        {/* Title */}
-        <h1 className="font-display mb-4 block text-5xl leading-none text-lion md:text-8xl">
-          sign up
-        </h1>
-
-        {/* Email */}
-        <input
-          type="text"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
-        />
-
-        {/* Password */}
-        <input
-          type="password"
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
-        />
-
-        {/* Retype Password */}
-        <input
-          type="password"
-          placeholder="Confirm Password"
-          value={confirmPassword}
-          onChange={(e) => setConfirmPassword(e.target.value)}
-          className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
-        />
-
-        {/* Sign Up Button */}
-        <div className="flex w-full">
-          <button
-            type="submit"
-            className="mb-2 ml-auto cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
-          >
+      {emailSent ? (
+        <div className="text-center">
+          <h2 className="mb-4 text-4xl font-bold">Check your email</h2>
+          <p className="mb-6">
+            A verification link was sent to{" "}
+            <span className="font-bold">{email}</span>.
+          </p>
+          <div className="flex justify-center gap-6">
+            <button
+              onClick={handleResendEmail}
+              className="mb-2 cursor-pointer rounded-full px-4 py-2 outline-2 outline-blue transition"
+            >
+              resend email
+            </button>
+            <Link
+              href="/login"
+              className="mb-2 cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
+            >
+              go to login
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <form
+          onSubmit={handleSubmit}
+          className="flex w-80 flex-col items-center"
+        >
+          {/* Title */}
+          <h1 className="font-display mb-4 block text-5xl leading-none text-lion md:text-8xl">
             sign up
-          </button>
-        </div>
+          </h1>
 
-        {/* Login Link */}
-        <div className="w-full text-right text-xs">
-          Already have an account?{" "}
-          <Link href="/login" className="cursor-pointer">
-            Login!
-          </Link>
-        </div>
-      </form>
+          {/* Email */}
+          <input
+            type="text"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
+          />
+
+          {/* Password */}
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
+          />
+
+          {/* Retype Password */}
+          <input
+            type="password"
+            placeholder="Confirm Password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
+          />
+
+          {/* Sign Up Button */}
+          <div className="flex w-full">
+            <button
+              type="submit"
+              className="mb-2 ml-auto cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
+            >
+              sign up
+            </button>
+          </div>
+
+          {/* Login Link */}
+          <div className="w-full text-right text-xs">
+            Already have an account?{" "}
+            <Link href="/login" className="cursor-pointer">
+              Login!
+            </Link>
+          </div>
+        </form>
+      )}
     </div>
   );
 }

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -3,13 +3,11 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import React, { useState } from "react";
-import MessagePage from "../ui/components/message-page";
 
 export default function Page() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [emailSent, setEmailSent] = useState(false);
   const router = useRouter();
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -22,92 +20,68 @@ export default function Page() {
 
     // TODO: Replace with real sign up API logic
     if (email && password && confirmPassword === password) {
-      setEmailSent(true);
+      // add the email to session storage to have it in the email-sent page without
+      // putting it in the URL
+      sessionStorage.setItem("sign_up_email", email);
+      router.push("/sign-up/email-sent");
     } else {
       alert("WOMP WOMP NO ACCOUNT FOR YOU");
     }
   };
 
-  const handleResendEmail = () => {
-    console.log("Resending email to:", email);
-    // TODO: Replace with real resend email API logic
-  };
-
   return (
     <div className="flex h-screen items-center justify-center">
-      {emailSent ? (
-        <MessagePage
-          title="Check your email"
-          description={`A verification link was sent to ${email}.`}
-          buttons={[
-            {
-              type: "secondary",
-              label: "resend email",
-              onClick: handleResendEmail,
-            },
-            {
-              type: "primary",
-              label: "go to login",
-              onClick: () => router.push("/login"),
-            },
-          ]}
+      <form onSubmit={handleSubmit} className="flex w-80 flex-col items-center">
+        {/* Title */}
+        <h1 className="font-display mb-4 block text-5xl leading-none text-lion md:text-8xl">
+          sign up
+        </h1>
+
+        {/* Email */}
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
         />
-      ) : (
-        <form
-          onSubmit={handleSubmit}
-          className="flex w-80 flex-col items-center"
-        >
-          {/* Title */}
-          <h1 className="font-display mb-4 block text-5xl leading-none text-lion md:text-8xl">
+
+        {/* Password */}
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
+        />
+
+        {/* Retype Password */}
+        <input
+          type="password"
+          placeholder="Confirm Password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
+        />
+
+        {/* Sign Up Button */}
+        <div className="flex w-full">
+          <button
+            type="submit"
+            className="mb-2 ml-auto cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
+          >
             sign up
-          </h1>
+          </button>
+        </div>
 
-          {/* Email */}
-          <input
-            type="email"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
-          />
-
-          {/* Password */}
-          <input
-            type="password"
-            placeholder="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
-          />
-
-          {/* Retype Password */}
-          <input
-            type="password"
-            placeholder="Confirm Password"
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            className="mb-4 w-full rounded-full border px-4 py-2 focus:ring-2 focus:outline-none"
-          />
-
-          {/* Sign Up Button */}
-          <div className="flex w-full">
-            <button
-              type="submit"
-              className="mb-2 ml-auto cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
-            >
-              sign up
-            </button>
-          </div>
-
-          {/* Login Link */}
-          <div className="w-full text-right text-xs">
-            Already have an account?{" "}
-            <Link href="/login" className="cursor-pointer">
-              Login!
-            </Link>
-          </div>
-        </form>
-      )}
+        {/* Login Link */}
+        <div className="w-full text-right text-xs">
+          Already have an account?{" "}
+          <Link href="/login" className="cursor-pointer">
+            Login!
+          </Link>
+        </div>
+      </form>
     </div>
   );
 }

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import React, { useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import React, { useState } from "react";
+import MessagePage from "../ui/components/message-page";
 
 export default function Page() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [emailSent, setEmailSent] = useState(false);
+  const router = useRouter();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -33,27 +36,22 @@ export default function Page() {
   return (
     <div className="flex h-screen items-center justify-center">
       {emailSent ? (
-        <div className="text-center">
-          <h2 className="mb-4 text-4xl font-bold">Check your email</h2>
-          <p className="mb-6">
-            A verification link was sent to{" "}
-            <span className="font-bold">{email}</span>.
-          </p>
-          <div className="flex justify-center gap-6">
-            <button
-              onClick={handleResendEmail}
-              className="mb-2 cursor-pointer rounded-full px-4 py-2 outline-2 outline-blue transition"
-            >
-              resend email
-            </button>
-            <Link
-              href="/login"
-              className="mb-2 cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
-            >
-              go to login
-            </Link>
-          </div>
-        </div>
+        <MessagePage
+          title="Check your email"
+          description={`A verification link was sent to ${email}.`}
+          buttons={[
+            {
+              type: "secondary",
+              label: "resend email",
+              onClick: handleResendEmail,
+            },
+            {
+              type: "primary",
+              label: "go to login",
+              onClick: () => router.push("/login"),
+            },
+          ]}
+        />
       ) : (
         <form
           onSubmit={handleSubmit}

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -66,7 +66,7 @@ export default function Page() {
 
           {/* Email */}
           <input
-            type="text"
+            type="email"
             placeholder="Email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}

--- a/app/ui/components/message-page.tsx
+++ b/app/ui/components/message-page.tsx
@@ -20,8 +20,8 @@ export default function MessagePage({
   return (
     <div className="text-center">
       <h2 className="mb-4 text-4xl font-bold">{title}</h2>
-      <p className="mb-6">{description}</p>
-      <div className="flex justify-center gap-6">
+      <p className="mb-4">{description}</p>
+      <div className="flex justify-center gap-4">
         {buttons.map((button, index) => (
           <button
             key={index}

--- a/app/ui/components/message-page.tsx
+++ b/app/ui/components/message-page.tsx
@@ -1,0 +1,37 @@
+import { ButtonType } from "@/app/_types/button-type";
+
+type ButtonData = { type: ButtonType; label: string; onClick: () => void };
+
+type MessagePageProps = {
+  title: string;
+  description: string;
+  buttons: ButtonData[];
+};
+
+export default function MessagePage({
+  title,
+  description,
+  buttons,
+}: MessagePageProps) {
+  return (
+    <div className="text-center">
+      <h2 className="mb-4 text-4xl font-bold">{title}</h2>
+      <p className="mb-6">{description}</p>
+      <div className="flex justify-center gap-6">
+        {buttons.map((button, index) => (
+          <button
+            key={index}
+            onClick={button.onClick}
+            className={`mb-2 cursor-pointer rounded-full px-4 py-2 font-medium transition ${
+              button.type === "primary"
+                ? "bg-blue dark:bg-red"
+                : "outline-2 outline-blue hover:bg-blue-100 dark:outline-red dark:hover:bg-red/25"
+            }`}
+          >
+            {button.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/ui/components/message-page.tsx
+++ b/app/ui/components/message-page.tsx
@@ -1,4 +1,8 @@
-import { ButtonType } from "@/app/_types/button-type";
+enum ButtonTypeEnum {
+  primary = "primary",
+  secondary = "secondary",
+}
+type ButtonType = keyof typeof ButtonTypeEnum;
 
 type ButtonData = { type: ButtonType; label: string; onClick: () => void };
 

--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+
+export default function Page() {
+  const [emailVerified, setEmailVerified] = useState(false);
+
+  return (
+    <div className="flex h-screen items-center justify-center">
+      {emailVerified ? (
+        <div className="text-center">
+          <h2 className="mb-4 text-4xl font-bold">Failed to Verify Email</h2>
+          <p className="mb-6">This link is invalid or has expired.</p>
+          <div className="flex justify-center gap-6">
+            <Link
+              href="/sign-up"
+              className="mb-2 cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
+            >
+              back to sign up
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <div className="text-center">
+          <h2 className="mb-4 text-4xl font-bold">Email Verified</h2>
+          <p className="mb-6">Welcome to Plancake!</p>
+          <div className="flex justify-center gap-6">
+            <Link
+              href="/login"
+              className="mb-2 cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
+            >
+              go to login
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -1,27 +1,42 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 
 export default function Page() {
+  const [verifying, setVerifying] = useState(true);
   const [emailVerified, setEmailVerified] = useState(false);
+
+  const searchParams = useSearchParams();
+  const token = searchParams.get("code");
+
+  useEffect(() => {
+    const verifyEmail = async () => {
+      if (!token) {
+        setVerifying(false);
+        setEmailVerified(false);
+        return;
+      }
+
+      // TODO: Replace with an actual API call
+      // randomly choose an outcome after a delay for now
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const success = Math.random() > 0.5;
+      setVerifying(false);
+      setEmailVerified(success);
+    };
+
+    verifyEmail();
+  }, [token]);
 
   return (
     <div className="flex h-screen items-center justify-center">
-      {emailVerified ? (
+      {verifying ? (
         <div className="text-center">
-          <h2 className="mb-4 text-4xl font-bold">Failed to Verify Email</h2>
-          <p className="mb-6">This link is invalid or has expired.</p>
-          <div className="flex justify-center gap-6">
-            <Link
-              href="/sign-up"
-              className="mb-2 cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
-            >
-              back to sign up
-            </Link>
-          </div>
+          <h2 className="mb-6">Verifying...</h2>
         </div>
-      ) : (
+      ) : emailVerified ? (
         <div className="text-center">
           <h2 className="mb-4 text-4xl font-bold">Email Verified</h2>
           <p className="mb-6">Welcome to Plancake!</p>
@@ -31,6 +46,19 @@ export default function Page() {
               className="mb-2 cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
             >
               go to login
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <div className="text-center">
+          <h2 className="mb-4 text-4xl font-bold">Failed to Verify Email</h2>
+          <p className="mb-6">This link is invalid or has expired.</p>
+          <div className="flex justify-center gap-6">
+            <Link
+              href="/sign-up"
+              className="mb-2 cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
+            >
+              back to sign up
             </Link>
           </div>
         </div>

--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
-import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
 import MessagePage from "../ui/components/message-page";
 
 export default function Page() {
@@ -15,6 +14,9 @@ export default function Page() {
 
   useEffect(() => {
     const verifyEmail = async () => {
+      // simulate network delay
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
       if (!token) {
         setVerifying(false);
         setEmailVerified(false);
@@ -22,11 +24,8 @@ export default function Page() {
       }
 
       // TODO: Replace with an actual API call
-      // randomly choose an outcome after a delay for now
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      const success = Math.random() > 0.5;
       setVerifying(false);
-      setEmailVerified(success);
+      setEmailVerified(true);
     };
 
     verifyEmail();

--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -2,11 +2,13 @@
 
 import React, { useState, useEffect } from "react";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
+import MessagePage from "../ui/components/message-page";
 
 export default function Page() {
   const [verifying, setVerifying] = useState(true);
   const [emailVerified, setEmailVerified] = useState(false);
+  const router = useRouter();
 
   const searchParams = useSearchParams();
   const token = searchParams.get("code");
@@ -37,31 +39,29 @@ export default function Page() {
           <h2 className="mb-6">Verifying...</h2>
         </div>
       ) : emailVerified ? (
-        <div className="text-center">
-          <h2 className="mb-4 text-4xl font-bold">Email Verified</h2>
-          <p className="mb-6">Welcome to Plancake!</p>
-          <div className="flex justify-center gap-6">
-            <Link
-              href="/login"
-              className="mb-2 cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
-            >
-              go to login
-            </Link>
-          </div>
-        </div>
+        <MessagePage
+          title="Email Verified"
+          description="Welcome to Plancake!"
+          buttons={[
+            {
+              type: "primary",
+              label: "go to login",
+              onClick: () => router.push("/login"),
+            },
+          ]}
+        />
       ) : (
-        <div className="text-center">
-          <h2 className="mb-4 text-4xl font-bold">Failed to Verify Email</h2>
-          <p className="mb-6">This link is invalid or has expired.</p>
-          <div className="flex justify-center gap-6">
-            <Link
-              href="/sign-up"
-              className="mb-2 cursor-pointer gap-2 rounded-full bg-blue px-4 py-2 font-medium transition"
-            >
-              back to sign up
-            </Link>
-          </div>
-        </div>
+        <MessagePage
+          title="Failed to Verify Email"
+          description="This link is invalid or has expired."
+          buttons={[
+            {
+              type: "secondary",
+              label: "back to sign up",
+              onClick: () => router.push("/sign-up"),
+            },
+          ]}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## What?
This PR adds more pages necessary for the authentication flow. A few small tweaks were also added to the existing auth pages.

### New Pages
- `/forgot-password` - This page did have a file, but it wasn't implemented until now.
- `/forgot-password/email-sent` - Displayed after submitting on the `/forgot-password` page.
- `/reset-password` - Reached via a URL sent by email from the `/forgot-password` page.
- `/reset-password/success` - Displayed after a successful password reset.
- `/sign-up/email-sent` - Displayed after a sign up is requested, and allows the user to resend the email.
- `/verify-email` - Reached via a URL sent by email from the `/sign-up` page.

### Existing Page Tweaks
- `/login` - The email input field now has a type of `email` just to help with input validation.
- `/sign-up` - Also changed the email input field type, but also now redirects to the `/sign-up/email-sent` page after submission.

### New Components
A new component, `MessagePage` was also created to help with the layout on some of these pages (`/email-sent` and `/success`). Since they all have the same format, it made sense to create a reusable component.

## Why?
The auth flow needed more pages to support all the functionality required.

## How?
🤷‍♂️

## Testing?
There aren't any API calls yet, but the pages look fine and the buttons navigate properly.