### PR TITLE
Fix link in hamburger menu

### DIFF
--- a/app/ui/components/hamburger-menu.tsx
+++ b/app/ui/components/hamburger-menu.tsx
@@ -51,7 +51,7 @@ export default function HamburgerMenu() {
           <div className="w-60 text-xl">
             <ul className="flex flex-col space-y-1 p-4">
               <li>
-                <Link href="/" className="tracking-wide">
+                <Link href="/new-event" className="tracking-wide">
                   Mix Your First Plan
                 </Link>
               </li>

--- a/app/ui/components/hamburger-menu.tsx
+++ b/app/ui/components/hamburger-menu.tsx
@@ -67,7 +67,7 @@ export default function HamburgerMenu() {
               </li>
               <li>
                 <Link href="/login" className="tracking-wide">
-                  Login/Signup
+                  Login
                 </Link>
               </li>
             </ul>


### PR DESCRIPTION
## What?
This PR adds proper navigation to the hamburger menu.

Most of it was already there, it was just missing the `/new-event` link.

I also changed the "Login/Signup" button to just say "Login", since that seems more intuitive and in line with other websites.

## Why?
Can't access other pages without links to them. Unless you're just great at guessing URLs.

## How?
I changed like two lines.

## Testing?
I clicked and got navigated.