### PR TITLE
Add auth API connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+certificates

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ To clone and run this application, [Node.js](https://nodejs.org/en/download/) (w
 npm install npm@latest -g
 ```
 
+### `.env` Setup
+
+Create a file called `.env` in the root directory, copying the contents of `example.env`.
+
+Replace all values in the file with the relevant information.
+
 ### Installation
 
 ```bash

--- a/app/_utils/format-api-error.tsx
+++ b/app/_utils/format-api-error.tsx
@@ -1,0 +1,36 @@
+function snakeToTitleCase(str: string): string {
+  return str
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export default function formatApiError(errors: any): string {
+  let errorMessage = "";
+  let generalMessage = "";
+  errors = errors.error;
+
+  if (errors.general) {
+    generalMessage = errors.general[0];
+  }
+
+  for (const field in errors) {
+    if (field !== "general" && Array.isArray(errors[field])) {
+      for (const msg of errors[field]) {
+        const fieldTitle = snakeToTitleCase(field);
+        errorMessage += `${fieldTitle}: ${msg}\n`;
+      }
+    }
+  }
+
+  if (errorMessage) {
+    if (generalMessage) {
+      return generalMessage + "\n" + errorMessage.trim();
+    }
+    return errorMessage.trim();
+  } else if (generalMessage) {
+    return generalMessage;
+  }
+
+  return "An unknown error has occurred.";
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -60,6 +60,10 @@ export default function Page() {
     );
   };
 
+  const logout = async () => {
+    alert("Logging out...");
+  };
+
   return (
     <div className="min-h-screen p-6">
       {/* Events You Joined */}
@@ -95,6 +99,16 @@ export default function Page() {
           ))}
         </div>
       </section>
+
+      {/* Logout Button */}
+      <div className="mt-8 flex justify-center">
+        <button
+          onClick={logout}
+          className="mb-2 cursor-pointer rounded-full bg-blue px-4 py-2 font-medium transition dark:bg-red"
+        >
+          Logout
+        </button>
+      </div>
     </div>
   );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,4 +1,8 @@
-import React from "react";
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useRef } from "react";
+import formatApiError from "../_utils/format-api-error";
 
 type Event = {
   id: string;
@@ -7,6 +11,9 @@ type Event = {
 };
 
 export default function Page() {
+  const router = useRouter();
+  const isSubmitting = useRef(false);
+
   // Mock data for testing
   const joinedEvents: Event[] = [
     {
@@ -61,7 +68,26 @@ export default function Page() {
   };
 
   const logout = async () => {
-    alert("Logging out...");
+    if (isSubmitting.current) return;
+    isSubmitting.current = true;
+
+    await fetch("/api/auth/logout/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    })
+      .then(async (res) => {
+        if (res.ok) {
+          router.push("/login");
+        } else {
+          alert(formatApiError(await res.json()));
+        }
+      })
+      .catch((err) => {
+        console.error("Fetch error:", err);
+        alert("An error occurred. Please try again.");
+      });
+
+    isSubmitting.current = false;
   };
 
   return (

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,22 +3,41 @@
 import React, { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import formatApiError from "../_utils/format-api-error";
 
 export default function Page() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const router = useRouter();
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    console.log("Login attempt:", { email, password });
 
-    // TODO: Replace with real authentication
-    if (email === "test" && password === "1234") {
-      router.push("/dashboard");
-    } else {
-      alert("Invalid email or password");
+    if (!email) {
+      alert("Missing email");
+      return;
     }
+    if (!password) {
+      alert("Missing password");
+      return;
+    }
+
+    await fetch("/api/auth/login/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    })
+      .then(async (res) => {
+        if (res.ok) {
+          router.push("/dashboard");
+        } else {
+          alert(formatApiError(await res.json()));
+        }
+      })
+      .catch((err) => {
+        console.error("Fetch error:", err);
+        alert("An error occurred. Please try again.");
+      });
   };
 
   return (

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -19,10 +19,12 @@ export default function Page() {
 
     if (!email) {
       alert("Missing email");
+      isSubmitting.current = false;
       return;
     }
     if (!password) {
       alert("Missing password");
+      isSubmitting.current = false;
       return;
     }
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import formatApiError from "../_utils/format-api-error";
@@ -8,10 +8,14 @@ import formatApiError from "../_utils/format-api-error";
 export default function Page() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const isSubmitting = useRef(false);
   const router = useRouter();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (isSubmitting.current) return;
+    isSubmitting.current = true;
 
     if (!email) {
       alert("Missing email");
@@ -38,6 +42,8 @@ export default function Page() {
         console.error("Fetch error:", err);
         alert("An error occurred. Please try again.");
       });
+
+    isSubmitting.current = false;
   };
 
   return (

--- a/app/sign-up/email-sent/page.tsx
+++ b/app/sign-up/email-sent/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import formatApiError from "@/app/_utils/format-api-error";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef } from "react";
 import MessagePage from "../../ui/layout/message-page";
@@ -23,7 +24,7 @@ export default function Page() {
     return null;
   }
 
-  const handleResendEmail = () => {
+  const handleResendEmail = async () => {
     const emailResendCooldown = 30000; // 30 seconds
     let timeLeft =
       (emailResendCooldown - (Date.now() - lastEmailResend.current)) / 1000;
@@ -32,8 +33,24 @@ export default function Page() {
       alert(`Slow down! ${timeLeft} seconds until you can send again.`);
       return;
     }
-    // TODO: Replace with real resend email API logic
-    console.log("Resending email to:", email);
+
+    await fetch("/api/auth/resend-register-email/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    })
+      .then(async (res) => {
+        if (res.ok) {
+          alert("Email resent. Please check your inbox.");
+        } else {
+          alert(formatApiError(await res.json()));
+        }
+      })
+      .catch((err) => {
+        console.error("Fetch error:", err);
+        alert("An error occurred. Please try again.");
+      });
+
     lastEmailResend.current = Date.now();
   };
 

--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
+import formatApiError from "../_utils/format-api-error";
 import MessagePage from "../ui/layout/message-page";
 
 export default function Page() {
@@ -14,18 +15,30 @@ export default function Page() {
 
   useEffect(() => {
     const verifyEmail = async () => {
-      // simulate network delay
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-
       if (!token) {
         setVerifying(false);
         setEmailVerified(false);
         return;
       }
 
-      // TODO: Replace with an actual API call
+      await fetch("/api/auth/verify-email/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ verification_code: token }),
+      })
+        .then(async (res) => {
+          if (res.ok) {
+            setEmailVerified(true);
+          } else {
+            // don't alert anything, the page will say enough
+          }
+        })
+        .catch((err) => {
+          console.error("Fetch error:", err);
+          alert("An error occurred. Please try again.");
+        });
+
       setVerifying(false);
-      setEmailVerified(true);
     };
 
     verifyEmail();

--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -29,8 +29,6 @@ export default function Page() {
         .then(async (res) => {
           if (res.ok) {
             setEmailVerified(true);
-          } else {
-            // don't alert anything, the page will say enough
           }
         })
         .catch((err) => {

--- a/example.env
+++ b/example.env
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=https://example.com/

--- a/example.env
+++ b/example.env
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_URL=https://example.com/
+NEXT_PUBLIC_API_URL=https://example.com

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,16 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["129.161.139.75"],
+
+  // Redirect API calls to the backend server for CORS stuff
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${process.env.NEXT_PUBLIC_API_URL}/:path*/`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack --experimental-https",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## What?
This PR finally starts connecting the frontend to the backend API.

### `.env` File
A `.env` file was added to specify the backend URL. `example.env` was also added to help other developers get up to speed, with instructions in the README.

### `--experimental-https` Added
The `--experimental-https` argument was added to the `npm run dev` script, so that cookies would work properly when testing locally.

### `formatApiError` Util Function
This was created to turn the JSON error format from the backend into a single string. This makes it easy to just create an alert from the error message in case something goes wrong. See the implemented API calls for examples.

### Actual API Functionality
API functionality was added to the following pages:
- Login
- Sign Up (actual registration + email resend on success)
- Verify Email
- Forgot Password
- Reset Password
- Dashboard (see below)

### Temporary Logout Button
There's no account button (in this branch), so I put a temporary logout button on the dashboard page since there's nowhere else good for it. It will get removed when the account button is added.

## Why?
A website is cool and all but what's the point without the backend data to support it?

## How?
The `fetch` API works wonders.

## Testing?
Some mild testing was done, but surely not much can go wrong for simple implementations like log in and sign up.